### PR TITLE
feat(db): add schema and seed data for brand/menu/nutrition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-database-postgresql'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/calocheck/calobackend/domain/Brand.java
+++ b/src/main/java/com/calocheck/calobackend/domain/Brand.java
@@ -1,0 +1,41 @@
+package com.calocheck.calobackend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "brand", indexes = {
+        @Index(name = "ux_brand_name", columnList = "name", unique = true)
+})
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor @Builder
+public class Brand {
+
+    @Id @GeneratedValue @UuidGenerator
+    private UUID id;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    @Column(nullable = false)      // 'cafe','restaurant','bakery','etc'
+    private String category;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/java/com/calocheck/calobackend/domain/Menu.java
+++ b/src/main/java/com/calocheck/calobackend/domain/Menu.java
@@ -1,0 +1,43 @@
+package com.calocheck.calobackend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "menu", uniqueConstraints = {
+        @UniqueConstraint(name = "ux_menu_brand_name", columnNames = {"brand_id", "name"})
+}, indexes = {
+        @Index(name = "ix_menu_name", columnList = "name")
+})
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Menu {
+
+    @Id @GeneratedValue @UuidGenerator
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "brand_id", nullable = false)
+    private Brand brand;
+
+    @Column(nullable = false, length = 255)
+    private String name;
+
+    private Integer price;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive = true;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/java/com/calocheck/calobackend/domain/Nutrition.java
+++ b/src/main/java/com/calocheck/calobackend/domain/Nutrition.java
@@ -1,0 +1,57 @@
+package com.calocheck.calobackend.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.annotations.UuidGenerator;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "nutrition", uniqueConstraints = {
+        @UniqueConstraint(name = "ux_nutrition_menu_size", columnNames = {"menu_id", "size"})
+}, indexes = {
+        @Index(name = "ix_nutrition_menu", columnList = "menu_id")
+})
+@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder
+public class Nutrition {
+
+    @Id @GeneratedValue @UuidGenerator
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(nullable = false)
+    private String size;
+
+    @Column(nullable = false)
+    private Integer calories;
+
+    @Column(precision = 6, scale = 1)
+    private BigDecimal protein;
+
+    @Column(precision = 6, scale = 1)
+    private BigDecimal fat;
+
+    @Column(precision = 6, scale = 1)
+    private BigDecimal carbohydrate;
+
+    @Column(precision = 6, scale = 1)
+    private BigDecimal sugar;
+
+    @Column(name = "caffeine_mg")
+    private Integer caffeineMg;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/src/main/java/com/calocheck/calobackend/repository/BrandRepository.java
+++ b/src/main/java/com/calocheck/calobackend/repository/BrandRepository.java
@@ -1,0 +1,13 @@
+package com.calocheck.calobackend.repository;
+
+
+import com.calocheck.calobackend.domain.Brand;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface BrandRepository extends JpaRepository<Brand, UUID> {
+    Optional<Brand> findByName(String name);
+    boolean existsByName(String name);
+}

--- a/src/main/java/com/calocheck/calobackend/repository/MenuRepository.java
+++ b/src/main/java/com/calocheck/calobackend/repository/MenuRepository.java
@@ -1,0 +1,15 @@
+package com.calocheck.calobackend.repository;
+
+import com.calocheck.calobackend.domain.Menu;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MenuRepository extends JpaRepository<Menu, UUID> {
+    Page<Menu> findByBrandId(UUID brandId, Pageable pageable);
+    Optional<Menu> findByBrandIdAndName(UUID brandId, String name);
+    Page<Menu> findByNameContainingIgnoreCase(String keyword, Pageable pageable);
+}

--- a/src/main/java/com/calocheck/calobackend/repository/NutritionRepository.java
+++ b/src/main/java/com/calocheck/calobackend/repository/NutritionRepository.java
@@ -1,0 +1,13 @@
+package com.calocheck.calobackend.repository;
+
+import com.calocheck.calobackend.domain.Nutrition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface NutritionRepository extends JpaRepository<Nutrition, UUID> {
+    List<Nutrition> findByMenuId(UUID menuId);
+    Optional<Nutrition> findByMenuIdAndSize(UUID menuId, String size);
+}

--- a/src/main/resources/db/devseed/R__dev_seed.sql
+++ b/src/main/resources/db/devseed/R__dev_seed.sql
@@ -1,0 +1,40 @@
+-- 브랜드
+WITH b AS (
+INSERT INTO brand (name, category)
+VALUES ('매머드커피','cafe')
+ON CONFLICT (name) DO NOTHING
+    RETURNING id
+    )
+SELECT 1;
+
+-- 메뉴
+WITH bid AS (
+    SELECT id AS brand_id FROM brand WHERE name='매머드커피'
+),
+     m AS (
+INSERT INTO menu (brand_id, name, price)
+SELECT brand_id, '콜드브루', 2500 FROM bid
+    ON CONFLICT (brand_id, name) DO NOTHING
+  RETURNING id, name
+)
+SELECT 1;
+
+WITH bid AS (SELECT id AS brand_id FROM brand WHERE name='매머드커피'),
+     m2 AS (
+INSERT INTO menu (brand_id, name, price)
+SELECT brand_id, '디카페인 아메리카노', 2700 FROM bid
+    ON CONFLICT (brand_id, name) DO NOTHING
+  RETURNING id, name
+)
+SELECT 1;
+
+-- 영양(사이즈별)
+INSERT INTO nutrition (menu_id, size, calories, protein, fat, carbohydrate, sugar, caffeine_mg)
+SELECT (SELECT id FROM menu WHERE name='콜드브루' AND brand_id=(SELECT id FROM brand WHERE name='매머드커피')),
+       'Regular', 10, 0.3, 0, 2, 0, 100
+    ON CONFLICT (menu_id, size) DO NOTHING;
+
+INSERT INTO nutrition (menu_id, size, calories, protein, fat, carbohydrate, sugar, caffeine_mg)
+SELECT (SELECT id FROM menu WHERE name='디카페인 아메리카노' AND brand_id=(SELECT id FROM brand WHERE name='매머드커피')),
+       'Regular', 5, 0.2, 0, 1, 0, 2
+    ON CONFLICT (menu_id, size) DO NOTHING;

--- a/src/main/resources/db/migration/V1__init_schema.sql
+++ b/src/main/resources/db/migration/V1__init_schema.sql
@@ -1,0 +1,43 @@
+-- UUID 생성 함수
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- 브랜드
+CREATE TABLE IF NOT EXISTS brand (
+                                     id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name       VARCHAR(255) NOT NULL,
+    category   TEXT NOT NULL CHECK (category IN ('cafe','restaurant','bakery','etc')),
+    image_url  TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP
+    );
+CREATE UNIQUE INDEX IF NOT EXISTS ux_brand_name ON brand(name);
+
+-- 메뉴
+CREATE TABLE IF NOT EXISTS menu (
+                                    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    brand_id   UUID NOT NULL REFERENCES brand(id) ON DELETE CASCADE,
+    name       VARCHAR(255) NOT NULL,
+    price      INT CHECK (price IS NULL OR price >= 0),
+    is_active  BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at TIMESTAMP
+    );
+CREATE UNIQUE INDEX IF NOT EXISTS ux_menu_brand_name ON menu(brand_id, name);
+CREATE INDEX IF NOT EXISTS ix_menu_name ON menu(name);
+
+-- 영양정보(사이즈별)
+CREATE TABLE IF NOT EXISTS nutrition (
+                                         id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    menu_id       UUID NOT NULL REFERENCES menu(id) ON DELETE CASCADE,
+    size          TEXT NOT NULL,
+    calories      INT  NOT NULL CHECK (calories >= 0),
+    protein       NUMERIC(6,1) CHECK (protein      IS NULL OR protein      >= 0),
+    fat           NUMERIC(6,1) CHECK (fat          IS NULL OR fat          >= 0),
+    carbohydrate  NUMERIC(6,1) CHECK (carbohydrate IS NULL OR carbohydrate >= 0),
+    sugar         NUMERIC(6,1) CHECK (sugar        IS NULL OR sugar        >= 0),
+    caffeine_mg   INT CHECK (caffeine_mg IS NULL OR caffeine_mg >= 0),
+    created_at    TIMESTAMP NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMP
+    );
+CREATE UNIQUE INDEX IF NOT EXISTS ux_nutrition_menu_size ON nutrition(menu_id, size);
+CREATE INDEX IF NOT EXISTS ix_nutrition_menu ON nutrition(menu_id);


### PR DESCRIPTION
- Flyway V1__init_schema.sql 추가 (brand/menu/nutrition 테이블)
- R__dev_seed.sql 추가 (매머드커피 더미 데이터)
- Brand/Menu/Nutrition 엔티티 및 JPA 레포지토리 생성
- docker, local 프로필에 flyway.locations 설정